### PR TITLE
Improvement/mobile add charts to all coins section

### DIFF
--- a/src/actions/getCoinsList.ts
+++ b/src/actions/getCoinsList.ts
@@ -2,8 +2,14 @@
 
 import { type ListCoin } from "@/lib/types/ListCoin";
 
-export async function getCoinsList(currency = "usd", page = 1) {
-  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&category=layer-1&order=market_cap_desc&per_page=50&page=${page}`;
+export async function getCoinsList(
+  currency = "usd",
+  page = 1,
+  sparkline = false
+) {
+  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=${currency}&category=layer-1&order=market_cap_desc&per_page=50&page=${page}${
+    sparkline ? "&sparkline=true" : ""
+  }`;
   const options: RequestInit = {
     method: "GET",
     headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import HomeNav from "@/components/homeComponents/HomeNav";
 import MarketOverview from "@/components/homeComponents/MarketOverview";
 
 export default async function Home() {
-  const coins = await actions.getCoinsList();
+  const coins = await actions.getCoinsList("usd", 1, true);
   return (
     <>
       <HomeNav />

--- a/src/components/homeComponents/MarketOverview/CoinOverviewChart.tsx
+++ b/src/components/homeComponents/MarketOverview/CoinOverviewChart.tsx
@@ -25,27 +25,32 @@ ChartJS.register(
 );
 
 const CoinOverviewChart = ({ coin }: CoinOverviewChartProps) => {
-  const datasets = [
-    {
-      label: "Price",
-      data: coin.sparkline_in_7d.price,
-      borderColor: "#8e9deb",
-      pointBackgroundColor: "transparent",
-      pointBorderColor: "transparent",
-      pointHoverBackgroundColor: "#8e9deb",
-      fill: {
-        target: "origin",
-        above: "#8e9eeb21",
-      },
-    },
-  ];
+  const labels = coin.sparkline_in_7d.price.map((_, i) => i);
+  const priceUp = coin.price_change_percentage_24h > 0;
+  const priceUpColor = "#28f625";
+  const priceDownColor = "#ff6465";
 
   return (
-    <div>
+    <div className="w-1/3 pointer-events-none">
       <Line
         data={{
-          labels: Array.from({ length: coin.sparkline_in_7d.price.length }),
-          datasets,
+          labels: labels,
+          datasets: [
+            {
+              label: "Price",
+              data: coin.sparkline_in_7d.price,
+              borderColor: priceUp ? priceUpColor : priceDownColor,
+              pointBackgroundColor: "transparent",
+              pointBorderColor: "transparent",
+              pointHoverBackgroundColor: priceUp
+                ? priceUpColor
+                : priceDownColor,
+              fill: {
+                target: "origin",
+                above: (priceUp ? priceUpColor : priceDownColor) + "21",
+              },
+            },
+          ],
         }}
         options={{
           elements: {

--- a/src/components/homeComponents/MarketOverview/CoinOverviewChart.tsx
+++ b/src/components/homeComponents/MarketOverview/CoinOverviewChart.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { Line } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+} from "chart.js/auto";
+import { ListCoin } from "@/lib/types/ListCoin";
+
+interface CoinOverviewChartProps {
+  coin: ListCoin;
+}
+
+ChartJS.register(
+  LinearScale,
+  CategoryScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip
+);
+
+const CoinOverviewChart = ({ coin }: CoinOverviewChartProps) => {
+  const datasets = [
+    {
+      label: "Price",
+      data: coin.sparkline_in_7d.price,
+      borderColor: "#8e9deb",
+      pointBackgroundColor: "transparent",
+      pointBorderColor: "transparent",
+      pointHoverBackgroundColor: "#8e9deb",
+      fill: {
+        target: "origin",
+        above: "#8e9eeb21",
+      },
+    },
+  ];
+
+  return (
+    <div>
+      <Line
+        data={{
+          labels: Array.from({ length: coin.sparkline_in_7d.price.length }),
+          datasets,
+        }}
+        options={{
+          elements: {
+            line: {
+              tension: 0.5,
+            },
+          },
+          plugins: {
+            legend: {
+              display: false,
+            },
+          },
+          scales: {
+            x: {
+              ticks: {
+                display: false,
+              },
+              grid: {
+                display: false,
+              },
+            },
+            y: {
+              ticks: {
+                display: false,
+              },
+              grid: {
+                display: false,
+              },
+            },
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default CoinOverviewChart;

--- a/src/components/homeComponents/MarketOverview/MobileCoinOverview.tsx
+++ b/src/components/homeComponents/MarketOverview/MobileCoinOverview.tsx
@@ -2,6 +2,7 @@ import { type ListCoin } from "@/lib/types/ListCoin";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
+import CoinOverviewChart from "./CoinOverviewChart";
 
 interface MobileCoinOverviewProps {
   coin: ListCoin;
@@ -32,6 +33,7 @@ const MobileCoinOverview = ({ coin }: MobileCoinOverviewProps) => {
         )}
         <p className="text-xs font-light text-gray-400">{coin.name}</p>
       </div>
+      <CoinOverviewChart coin={coin} />
       <div className="flex-1 text-right">
         <p className="font-medium">{displayPrice}</p>
         <p

--- a/src/components/homeComponents/MarketOverview/MobileCoinOverview.tsx
+++ b/src/components/homeComponents/MarketOverview/MobileCoinOverview.tsx
@@ -16,25 +16,30 @@ const MobileCoinOverview = ({ coin }: MobileCoinOverviewProps) => {
   const displayPriceChange = coin.price_change_percentage_24h
     ? coin.price_change_percentage_24h.toFixed(2) + "%"
     : "No data";
+
   return (
     <Link
       href={`/coin/${coin.id}`}
       className="flex gap-4 items-center bg-white dark:bg-violet-950/90 rounded-md p-3 text-black dark:text-white"
     >
-      <Image
-        src={coin.image}
-        alt={"logo for " + coin.name}
-        width={24}
-        height={24}
-      />
-      <div>
+      {coin.image !== "missing_large.png" && (
+        <Image
+          src={coin.image}
+          alt={"logo for " + coin.name}
+          width={24}
+          height={24}
+        />
+      )}
+      <div className="flex-1">
         {coin.symbol && (
           <p className="font-medium">{coin.symbol.toUpperCase()}</p>
         )}
         <p className="text-xs font-light text-gray-400">{coin.name}</p>
       </div>
-      <CoinOverviewChart coin={coin} />
-      <div className="flex-1 text-right">
+      {coin.sparkline_in_7d.price.length > 0 && (
+        <CoinOverviewChart coin={coin} />
+      )}
+      <div className="text-right flex-1">
         <p className="font-medium">{displayPrice}</p>
         <p
           className={`text-xs ${

--- a/src/components/homeComponents/MarketOverview/index.tsx
+++ b/src/components/homeComponents/MarketOverview/index.tsx
@@ -28,7 +28,8 @@ const MarketOverview = ({ startingCoins }: MarketOverviewProps) => {
   const fetchCoins = async () => {
     const data = (await getCoinsList(
       selectedCurrency,
-      currentPage + 1
+      currentPage + 1,
+      true
     )) as ListCoin[];
     if (!data.length || data.length === 0) {
       setHasMore(false);

--- a/src/lib/types/ListCoin.ts
+++ b/src/lib/types/ListCoin.ts
@@ -15,6 +15,9 @@ export interface ListCoin {
   market_cap_change_24h: number;
   market_cap_change_percentage_24h: number;
   circulating_supply: number;
+  sparkline_in_7d: {
+    price: number[];
+  };
   total_supply: number;
   max_supply: number;
   ath: number;


### PR DESCRIPTION
I added a sparkline chart to the market overview section on the home page, still only on mobile. I also added a check to make sure a coin has an image since one of the coins it tried loading did not and it crashed the app. I will have to update other parts of the app in an upcoming PR. 