### PR TITLE
Bug/fix the way currency is stored

### DIFF
--- a/src/components/PortfolioComponents/AddPortfolioForm.tsx
+++ b/src/components/PortfolioComponents/AddPortfolioForm.tsx
@@ -16,7 +16,7 @@ import { MarketDataArray } from "@/utils/types/MarketDataArray";
 const AddPortfolioForm = () => {
   const selectedCurrency = useAppSelector(
     (state) => state.preferences.selectedCurrency
-  ).toLowerCase();
+  );
   const dispatch = useAppDispatch();
   const [selectedCoin, setSelectedCoin] = useState<SearchResult | null>(null);
   const [amount, setAmount] = useState("");

--- a/src/components/PortfolioComponents/PortfolioCoinDetails.tsx
+++ b/src/components/PortfolioComponents/PortfolioCoinDetails.tsx
@@ -30,7 +30,7 @@ const PortfolioCoinDetails = ({
   const [formSubmitAttempted, setFormSubmitAttempted] = useState(false);
   const selectedCurrency = useAppSelector(
     (state) => state.preferences.selectedCurrency
-  ).toLowerCase();
+  );
   const dispatch = useAppDispatch();
   const today = new Date().toISOString().split("T")[0];
   const oneYearAgo = new Date(today);

--- a/src/components/PortfolioComponents/PortfolioCoins.tsx
+++ b/src/components/PortfolioComponents/PortfolioCoins.tsx
@@ -16,7 +16,7 @@ const PortfolioCoins = () => {
   const coins = useAppSelector((state) => state.portfolio.coins);
   const selectedCurrency = useAppSelector(
     (state) => state.preferences.selectedCurrency
-  ).toLowerCase();
+  );
 
   useEffect(() => {
     const fetchCoins = async () => {

--- a/src/components/UI/CurrencySelectorDropdown.tsx
+++ b/src/components/UI/CurrencySelectorDropdown.tsx
@@ -20,7 +20,7 @@ const CurrencySelectorDropdown = ({
   const dispatch = useAppDispatch();
 
   const handleSelectCurrency = async (currency: string) => {
-    dispatch(setSelectedCurrency(currency.toLowerCase()));
+    dispatch(setSelectedCurrency(currency));
     const newCoinsList = await actions.getCoinsList(currency, 1, true);
     dispatch(setCoins(newCoinsList));
   };

--- a/src/components/UI/CurrencySelectorDropdown.tsx
+++ b/src/components/UI/CurrencySelectorDropdown.tsx
@@ -20,7 +20,7 @@ const CurrencySelectorDropdown = ({
   const dispatch = useAppDispatch();
 
   const handleSelectCurrency = async (currency: string) => {
-    dispatch(setSelectedCurrency(currency));
+    dispatch(setSelectedCurrency(currency.toLowerCase()));
     const newCoinsList = await actions.getCoinsList(currency, 1, true);
     dispatch(setCoins(newCoinsList));
   };

--- a/src/lib/features/preferences/preferencesSlice.ts
+++ b/src/lib/features/preferences/preferencesSlice.ts
@@ -8,7 +8,7 @@ export interface PreferencesState {
 }
 
 const initialState: PreferencesState = {
-  selectedCurrency: "USD",
+  selectedCurrency: "usd",
   darkMode: true,
   searchDrawerOpen: false,
   supportedCurrencies: [],


### PR DESCRIPTION
Realized that selected currency was being initialized to capital USD instead of usd which was causing errors when trying to load portfolio coins. I was able to remove a few unnecessary calls to toLowerCase thanks to this.